### PR TITLE
Fix for labelling nodes with fqdn-hostnames

### DIFF
--- a/roles/tools/tasks/labels.yml
+++ b/roles/tools/tasks/labels.yml
@@ -8,5 +8,13 @@
     shell: kubectl label nodes {{ inventory_hostname_short }} {{label | default ("node-role.kubernetes.io/compute=") }} --overwrite
     register: command_result
     changed_when: '"not labeled" not in command_result.stdout'
-
+    ignore_errors: yes
+  - name: labeling with fqdn hostname
+    delegate_to: "{{groups['primary-master'][0]}}"
+    environment:
+      KUBECONFIG: /etc/kubernetes/admin.conf
+    shell: kubectl label nodes {{ inventory_hostname }} {{label | default ("node-role.kubernetes.io/compute=") }} --overwrite
+    register: command_result
+    changed_when: '"not labeled" not in command_result.stdout'
+    ignore_errors: yes
 


### PR DESCRIPTION
Fix for #71 
Just added a second task that uses long hostnames and have both tasks ignore errors.
One of both will succeed. Should be easier than trying to detect if long or short hostnames are used.
