### PR TITLE
Fix sanity check failure because containerd dir does not exist

### DIFF
--- a/roles/common/tasks/docker.yml
+++ b/roles/common/tasks/docker.yml
@@ -240,7 +240,7 @@
     #   - docker
 
     - name: "sanity - make sure master is up (sometimes the above condition is empty as master is in fact not working..."
-      shell: "sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null "
+       shell: "sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null || mkdir -p /etc/containerd && sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null"
       notify:
       - Restart containerd
       tags:


### PR DESCRIPTION
The update is meant to fix an error on this check when containerd install does not create the /etc/containerd folder. Had this problem while running the "all_install.yml" playbook. Creating the directory and re-running the command makes the trick. 

More info:
- VM on Hetzner Cloud - 22.04 5.15.0-56-generic 62-Ubuntu
- Containerd - 1.5.9-0ubuntu3.1