### PR TITLE
fixes #98: remove excessive comma in docker config that blocks it from starting

### DIFF
--- a/roles/common/tasks/docker.yml
+++ b/roles/common/tasks/docker.yml
@@ -251,7 +251,7 @@
       lineinfile:
         dest: /etc/containerd/config.toml
         regexp: '^(.*)sandbox_image = "registry.k8s.io/pause(.*)$'
-        line: '\1sandbox_image = "{{ images_repo | default ("registry.k8s.io") }}/pause\2'
+        line: '\1sandbox_image = "{{ images_repo | default ("registry.k8s.io") }}/pause\2"'
         backrefs: yes
       notify:
       - Restart containerd

--- a/roles/common/tasks/docker.yml
+++ b/roles/common/tasks/docker.yml
@@ -137,7 +137,7 @@
              "log-opts": {
                 "max-size": "1000m",
                 "max-file": "3"
-             },
+             }
           }
         dest: /etc/docker/daemon.json
         backup: yes
@@ -251,7 +251,7 @@
       lineinfile:
         dest: /etc/containerd/config.toml
         regexp: '^(.*)sandbox_image = "registry.k8s.io/pause(.*)$'
-        line: '\1sandbox_image = "{{ images_repo | default ("registry.k8s.io") }}/pause\2"'
+        line: '\1sandbox_image = "{{ images_repo | default ("registry.k8s.io") }}/pause\2'
         backrefs: yes
       notify:
       - Restart containerd


### PR DESCRIPTION
Removing excessive comma as reported in #98 
edit: added also fix for containerd config