### PR TITLE
fix docker install storage for ZFS + quote in contianerd config

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ group_vars/all/temp.yaml
 containerd:
   ## if FS used by containerd is zfs (e.g. Ubuntu 20.04+)
   snapshotter: zfs
+  ## if using the playbook to also install docker/containerd, storage driver needs to be overriden too. It still assumes /var/lib/docker and /var/lib/containerd/io.containerd.snapshotter.v1.zfs are on ZFS. 
+  storage_driver: zfs
 
 ## Override version
 KUBERNETES_VERSION_CUSTOM: "1.26.0"

--- a/roles/common/tasks/docker.yml
+++ b/roles/common/tasks/docker.yml
@@ -137,7 +137,7 @@
              "log-opts": {
                 "max-size": "1000m",
                 "max-file": "3"
-             },
+             }
           }
         dest: /etc/docker/daemon.json
         backup: yes
@@ -251,7 +251,7 @@
       lineinfile:
         dest: /etc/containerd/config.toml
         regexp: '^(.*)sandbox_image = "registry.k8s.io/pause(.*)$'
-        line: '\1sandbox_image = "{{ images_repo | default ("registry.k8s.io") }}/pause\2"'
+        line: '\1sandbox_image = "{{ images_repo | default ("registry.k8s.io") }}/pause\2'
         backrefs: yes
       notify:
       - Restart containerd

--- a/roles/common/tasks/docker.yml
+++ b/roles/common/tasks/docker.yml
@@ -128,11 +128,11 @@
       notify:
       - Restart docker
 
-    - name: set docker storage to overlay2 (Debian / RH new) - overlay2 works only with ubuntu's official docker distribution (docker.io)
+    - name: set docker storage to {{ containerd.storage_driver|default('overlay2') }} (Debian / RH new) - overlay2 works only with ubuntu's official docker distribution (docker.io)
       copy:
         content: |
           {
-            "storage-driver": "overlay2",
+            "storage-driver": "{{ containerd.storage_driver|default('overlay2') }}",
              "exec-opts": ["native.cgroupdriver=systemd"],
              "log-opts": {
                 "max-size": "1000m",
@@ -250,8 +250,8 @@
     - name: Make sure containerd sandbox_image does not pull img from outside to avoid proxy issues
       lineinfile:
         dest: /etc/containerd/config.toml
-        regexp: '^(.*)sandbox_image = "registry.k8s.io/pause(.*)$'
-        line: '\1sandbox_image = "{{ images_repo | default ("registry.k8s.io") }}/pause\2'
+        regexp: '^(.*)sandbox_image = "registry.k8s.io/pause(.*)"$'
+        line: '\1sandbox_image = "{{ images_repo | default ("registry.k8s.io") }}/pause\2"'
         backrefs: yes
       notify:
       - Restart containerd


### PR DESCRIPTION
Added option to set storage driver for ZFS

changed the matching regex, as the commit 4ebc48e3964ab8c2ca97d54e3e0ca9d7c05ee15a re-added the quote, but forgets that the quote is rleady in the `\2` backquote, so changing the matching regex instead to make it more clear.

future TODO: pre-flight checks that `/var/lib/docker` and `/var/lib/containerd/io.containerd.snapshotter.v1.zfs` are on ZFS filesystem if snapshotter is set to ZFS