### PR TITLE
allow to override SystemdCgroup

### DIFF
--- a/roles/common/tasks/docker.yml
+++ b/roles/common/tasks/docker.yml
@@ -272,6 +272,20 @@
       tags:
       - docker
 
+    - name: Make sure SystemdCrgoup is the desired one
+      lineinfile:
+        dest: /etc/containerd/config.toml
+        regexp: '^(.*)SystemdCgroup = .*$'
+        line: '\1SystemdCgroup = {{ containerd.systemd_cgroup | default ("false") }}'
+        backrefs: yes
+      when:
+      - containerd is defined
+      - containerd.systemd_cgroup is defined
+      notify:
+      - Restart containerd
+      tags:
+      - docker
+
     when:
     - ansible_os_family == "Debian" or ( ansible_os_family == "RedHat" and old_docker is undefined )
     ## END of Debian/Ubuntu block


### PR DESCRIPTION
on debian 12, etcd will fail after reboot if SystemdCgroup is not true. this will allow to set it in vars.