### PR TITLE
allow to configure delay in helm charts

### DIFF
--- a/roles/helm/tasks/charts_deploy.yml
+++ b/roles/helm/tasks/charts_deploy.yml
@@ -52,7 +52,7 @@
     - helm.packages_list is defined
     - ( item.namespace is not defined ) or ( item.namespace == "" )
     retries: 3
-    delay: 3
+    delay: "{{ CHARTS_DELAY | default(3) }}"
     register: result
     until: result is not failed
 
@@ -72,7 +72,7 @@
     - item.namespace is defined
     - item.namespace != ""
     retries: 3
-    delay: 3
+    delay: "{{ CHARTS_DELAY | default(3) }}"
     register: result
     until: result is not failed
 


### PR DESCRIPTION
On slower machines (eg development one node ones), delay of 3 seconds is not enough, causing `Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress` because it's retried too early.

this allows to override CHARTS_DELAY in ansible vars, with default being the original 3 seconds.